### PR TITLE
Added further action feature for key expansion

### DIFF
--- a/sotlisp.el
+++ b/sotlisp.el
@@ -158,7 +158,9 @@ non-nil."
   "Functions which may be called after expansion")
 
 (defun sotlisp--get-key-desc ()
-  (key-description (read-key-sequence-vector "Key: ")))
+  (replace-regexp-in-string
+   "\"" "\\\\\""
+   (key-description (read-key-sequence-vector "Key: "))))
 
 (defun sotlisp--move-to-$ ()
   "Move backwards until `$' and delete it.


### PR DESCRIPTION
Hi, thank you for this package, I really like it!

 I was tired of typing in the right format after expanding (kbd ""). Because of that I just added functionality to prompt for the key after expansion and insert it in the right format. It works like this:
The expansion can now include a semicolon like this:

`("k" . "kbd \"$;k\"")`

The char after the semicolon is used to search for appropriate function in `sotlisp--further-actions`.
These functions should return a string which then gets inserted after the expansion.  

If you like it, include it otherwise feel free to ignore the PR.
