### PR TITLE
added feature expansion

### DIFF
--- a/sotlisp.el
+++ b/sotlisp.el
@@ -201,11 +201,17 @@ space ahead."
 (defvar sotlisp--function-table (make-hash-table :test #'equal)
   "Table where function abbrev expansions are stored.")
 
+(defvar sotlisp--current-feature nil)
+(make-variable-buffer-local 'sotlisp--current-feature)
+
 (defun sotlisp--get-feature ()
-  (save-excursion
-    (goto-char (point-min))
-    (when (search-forward-regexp "^(provide '" nil 'noerror)
-      (thing-at-point 'symbol))))
+  (unless sotlisp--current-feature
+    (setq sotlisp--current-feature
+	  (save-excursion
+	    (goto-char (point-min))
+	    (when (search-forward-regexp "^(provide '" nil 'noerror)
+	      (thing-at-point 'symbol)))))
+  sotlisp--current-feature)
 
 (defun sotlisp--expand-function ()
   "Expand the function abbrev before point.

--- a/sotlisp.el
+++ b/sotlisp.el
@@ -446,6 +446,8 @@ following way:
     :enable-function #'sotlisp--function-p)
   (puthash name expansion sotlisp--function-table))
 
+(abbrev-table-put emacs-lisp-mode-abbrev-table :regexp "\\([\\s_a-z0-9]+\\)")
+
 (defun sotlisp-erase-all-abbrevs ()
   "Undefine all abbrevs defined by `sotlisp'."
   (interactive)

--- a/sotlisp.el
+++ b/sotlisp.el
@@ -222,7 +222,7 @@ See `sotlisp-define-function-abbrev'."
           (skeleton-insert (cons "" expansion)))
         t)
        ((or (stringp expansion)
-	    (and (string-prefix-p "-" name)
+	    (and (string-match "\\`-[^-]" name)
 		 (setq feature (sotlisp--get-feature))))
 	(when feature (setq expansion
 			    (concat feature (thing-at-point 'symbol)

--- a/sotlisp.el
+++ b/sotlisp.el
@@ -138,10 +138,10 @@ non-nil."
   (save-excursion
     (ignore-errors
       (skip-syntax-backward "w_")
-      (and (sotlisp--code-p)
-           (or (sotlisp--function-form-p)
-               (sotlisp--function-quote-p)
-	       (sotlisp--feature-abbrev-p))))))
+      (or (sotlisp--feature-abbrev-p)
+	  (and (sotlisp--code-p)
+	       (or (sotlisp--function-form-p)
+		   (sotlisp--function-quote-p)))))))
 
 (defun sotlisp--whitespace-p ()
   "Non-nil if current `self-insert'ed char is whitespace."


### PR DESCRIPTION
Hi,

I have added functionality to expand a feature if a symbols starts with a dash. For example if in `sotlisp.el` buffer "-test" will expand  to
"sotlisp-test". 
