### PR TITLE
Detect argument lists in more places

### DIFF
--- a/sotlisp.el
+++ b/sotlisp.el
@@ -100,7 +100,12 @@
   "Non-nil if point is at the start of a sexp.
 Specially, avoids matching inside argument lists."
   (and (eq (char-before) ?\()
-       (not (sotlisp--looking-back "(\\(defun\\s-+.*\\|\\(lambda\\|dolist\\|dotimes\\)\\s-+\\)("))
+       (not (sotlisp--looking-back
+             (rx (or (seq (? "cl-") (or "defun" "defmacro" "defsubst") (? "*")
+                          symbol-end (* any))
+                     (seq (or "lambda" "dolist" "dotimes")
+                          symbol-end (+ (syntax whitespace))))
+                 "(")))
        (save-excursion
          (forward-char -1)
          (condition-case nil

--- a/sotlisp.el
+++ b/sotlisp.el
@@ -109,7 +109,7 @@ Specially, avoids matching inside argument lists."
                (forward-sexp -1)
                (not
                 (looking-at-p (rx (* (or (syntax word) (syntax symbol) "-"))
-                                  "let" symbol-end))))
+                                  "let" (? "*") symbol-end))))
            (error t)))
        (not (string-match (rx (syntax symbol)) (string last-command-event)))))
 


### PR DESCRIPTION
Expand support for not expanding abbrevs in argument lists to the following special forms:
`let*`, `when-let*`, `defmacro`, `defsubst`, `cl-defun`, `defun*` etc.