### PR TITLE
Fix keys not being bound by the minor mode

### DIFF
--- a/sotlisp.el
+++ b/sotlisp.el
@@ -488,6 +488,7 @@ If `speed-of-thought-mode' is already on, call ON."
 (define-minor-mode sotlisp-mode
   "Local mode for editing Lisp at the speed of thought."
   :lighter " SoT"
+  :keymap
   `(([M-return] . sotlisp-newline-and-parentheses)
     ([C-return] . sotlisp-downlist-newline-and-parentheses)
     (,(kbd "C-M-;") . ,(if (fboundp 'comment-or-uncomment-sexp)


### PR DESCRIPTION
I have realized the keybindings are not applied when the minor mode is enabled.
I think that is due to the alist defining the keymap is not prefixed with the ":keymap" keyword in this line:

https://github.com/Malabarba/speed-of-thought-lisp/blob/04186129f2dccf48e288639b78adeb9c0e94be54/sotlisp.el#L491

I am not well versed with elisp but I think `define-minor-mode` will just consider it part of the body where it has no effect.
Having tried it in a fork adding the :keymap keyword works and enables the keybings as intended